### PR TITLE
Apply base card wrapper CSS for notice and main message

### DIFF
--- a/frontend/src/pages/home/home.css
+++ b/frontend/src/pages/home/home.css
@@ -1,5 +1,5 @@
 .wrapper-overlay {
-    padding: 2rem 4rem;
+    padding: 2vh 4vw;
 }
 
 .main-video-container {

--- a/frontend/src/pages/home/home.tsx
+++ b/frontend/src/pages/home/home.tsx
@@ -180,7 +180,7 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
                     </div>
                     <div id="message-anchor" className="justify-center">
                         <div className="justify-align-center">
-                            <AnnouncementSection data={this.state.announcements} customSectionStyle="single-column notice-container"/>
+                            <AnnouncementSection data={this.state.announcements} customSectionStyle="single-column notice-container wrapper-overlay"/>
                         </div>
                     </div>
                     <div className="justify-center padding-top">
@@ -188,7 +188,7 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
                             {(value: LanguageContextValue) => {
                                 const {language} = value;
                                 return (
-                                    <div className="justify-align-center notice-container" style={{"whiteSpace": "pre-line"}}>
+                                    <div className="justify-align-center notice-container wrapper-overlay" style={{"whiteSpace": "pre-line"}}>
                                         <MessageCard key={1} object={{ messageID: 0,
                                             tl_msg: "To Haato-sama,\n\n\
                                             I am the initiator of this project, W.Y. Hsieh.\n\n\

--- a/frontend/src/shared/globalStyles/global.css
+++ b/frontend/src/shared/globalStyles/global.css
@@ -51,7 +51,6 @@
 
 .notice-container {
     width: 100%;
-    min-width: 420px;
 }
 
 @media (max-width: 900px) {
@@ -97,6 +96,5 @@
     }
     .notice-container {
         max-width: 100vw;
-        min-width: 100vw;
     }
 }

--- a/frontend/src/shared/globalStyles/global.css
+++ b/frontend/src/shared/globalStyles/global.css
@@ -55,7 +55,7 @@
 
 @media (max-width: 900px) {
     .notice-container {
-        max-width: 90%;
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
Add wrapper-overlay for notice and main message so that in resolution with width >= 768px 
![image](https://user-images.githubusercontent.com/30451707/120329886-7d129a00-c316-11eb-8024-9cd810040b3a.png)
